### PR TITLE
Remove retryIndicator passed to driver.execute()

### DIFF
--- a/pyqldbsamples/add_secondary_owner.py
+++ b/pyqldbsamples/add_secondary_owner.py
@@ -126,8 +126,7 @@ if __name__ == '__main__':
     gov_id = SampleData.PERSON[0]['GovId']
     try:
         with create_qldb_driver() as driver:
-            driver.execute_lambda(lambda executor: register_secondary_owner(executor, vin, gov_id),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+            driver.execute_lambda(lambda executor: register_secondary_owner(executor, vin, gov_id))
             logger.info('Secondary owners successfully updated.')
     except Exception:
         logger.exception('Error adding secondary owner.')

--- a/pyqldbsamples/create_index.py
+++ b/pyqldbsamples/create_index.py
@@ -65,8 +65,7 @@ if __name__ == '__main__':
                                    and create_index(x, Constants.DRIVERS_LICENSE_TABLE_NAME,
                                                     Constants.PERSON_ID_INDEX_NAME)
                                    and create_index(x, Constants.DRIVERS_LICENSE_TABLE_NAME,
-                                                    Constants.LICENSE_NUMBER_INDEX_NAME),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+                                                    Constants.LICENSE_NUMBER_INDEX_NAME))
             logger.info('Indexes created successfully.')
     except Exception:
         logger.exception('Unable to create indexes.')

--- a/pyqldbsamples/create_table.py
+++ b/pyqldbsamples/create_table.py
@@ -54,8 +54,7 @@ if __name__ == '__main__':
             qldb_driver.execute_lambda(lambda x: create_table(x, Constants.DRIVERS_LICENSE_TABLE_NAME) and
                                    create_table(x, Constants.PERSON_TABLE_NAME) and
                                    create_table(x, Constants.VEHICLE_TABLE_NAME) and
-                                   create_table(x, Constants.VEHICLE_REGISTRATION_TABLE_NAME),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+                                   create_table(x, Constants.VEHICLE_REGISTRATION_TABLE_NAME))
             logger.info('Tables created successfully.')
     except Exception:
         logger.exception('Errors creating tables.')

--- a/pyqldbsamples/deregister_drivers_license.py
+++ b/pyqldbsamples/deregister_drivers_license.py
@@ -56,7 +56,6 @@ if __name__ == '__main__':
 
     try:
         with create_qldb_driver() as driver:
-            driver.execute_lambda(lambda executor: deregister_drivers_license(executor, license_number),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+            driver.execute_lambda(lambda executor: deregister_drivers_license(executor, license_number))
     except Exception:
         logger.exception('Error deleting driver license.')

--- a/pyqldbsamples/find_vehicles.py
+++ b/pyqldbsamples/find_vehicles.py
@@ -55,7 +55,6 @@ if __name__ == '__main__':
         with create_qldb_driver() as driver:
             # Find all vehicles registered under a person.
             gov_id = SampleData.PERSON[0]['GovId']
-            driver.execute_lambda(lambda executor: find_vehicles_for_owner(executor, gov_id),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+            driver.execute_lambda(lambda executor: find_vehicles_for_owner(executor, gov_id))
     except Exception:
         logger.exception('Error getting vehicles for owner.')

--- a/pyqldbsamples/get_block.py
+++ b/pyqldbsamples/get_block.py
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     vin = SampleData.VEHICLE_REGISTRATION[1]['VIN']
     try:
         with create_qldb_driver() as driver:
-            cursor = driver.execute_lambda(lambda executor: lookup_registration_for_vin(executor, vin))
+            cursor = lookup_registration_for_vin(driver, vin)
             row = next(cursor)
             block_address = row.get('blockAddress')
             verify_block(Constants.LEDGER_NAME, block_address)

--- a/pyqldbsamples/get_revision.py
+++ b/pyqldbsamples/get_revision.py
@@ -74,8 +74,7 @@ def lookup_registration_for_vin(driver, vin):
     """
     logger.info("Querying the 'VehicleRegistration' table for VIN: {}...".format(vin))
     query = 'SELECT * FROM _ql_committed_VehicleRegistration WHERE data.VIN = ?'
-    parameters = [convert_object_to_ion(vin)]
-    cursor = driver.execute_lambda( lambda txn: txn.execute_statement(query, parameters))
+    cursor = driver.execute_lambda(lambda txn: txn.execute_statement(query, convert_object_to_ion(vin)))
     return cursor
 
 

--- a/pyqldbsamples/insert_document.py
+++ b/pyqldbsamples/insert_document.py
@@ -95,8 +95,7 @@ if __name__ == '__main__':
         with create_qldb_driver() as driver:
             # An INSERT statement creates the initial revision of a document with a version number of zero.
             # QLDB also assigns a unique document identifier in GUID format as part of the metadata.
-            driver.execute_lambda(lambda executor: update_and_insert_documents(executor),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+            driver.execute_lambda(lambda executor: update_and_insert_documents(executor))
             logger.info('Documents inserted successfully!')
     except Exception:
         logger.exception('Error inserting or updating documents.')

--- a/pyqldbsamples/insert_ion_types.py
+++ b/pyqldbsamples/insert_ion_types.py
@@ -213,8 +213,7 @@ def insert_and_verify_ion_types(driver):
                                                              IonType.SYMBOL)
                            and update_record_and_verify_type(transaction_executor, ion_null_timestamp,
                                                              IonPyNull, IonType.TIMESTAMP)
-                           and delete_table(transaction_executor, TABLE_NAME),
-                           lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+                           and delete_table(transaction_executor, TABLE_NAME))
 
 
 if __name__ == '__main__':

--- a/pyqldbsamples/query_history.py
+++ b/pyqldbsamples/query_history.py
@@ -73,8 +73,7 @@ if __name__ == '__main__':
     try:
         with create_qldb_driver() as driver:
             vin = SampleData.VEHICLE_REGISTRATION[0]['VIN']
-            driver.execute_lambda(lambda lambda_executor: previous_primary_owners(lambda_executor, vin),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+            driver.execute_lambda(lambda lambda_executor: previous_primary_owners(lambda_executor, vin))
             logger.info('Successfully queried history.')
     except Exception:
         logger.exception('Unable to query history to find previous owners.')

--- a/pyqldbsamples/renew_drivers_license.py
+++ b/pyqldbsamples/renew_drivers_license.py
@@ -118,7 +118,6 @@ if __name__ == '__main__':
         with create_qldb_driver() as driver:
             license_number = SampleData.DRIVERS_LICENSE[0]['LicenseNumber']
             driver.execute_lambda(lambda executor: verify_and_renew_license(executor, license_number,
-                                                                             VALID_FROM_DATE, VALID_TO_DATE),
-                                   lambda retry_attempt: logger.info('Retrying due to OCC conflict...'))
+                                                                             VALID_FROM_DATE, VALID_TO_DATE))
     except Exception:
         logger.exception('Error renewing drivers license.')

--- a/pyqldbsamples/scan_table.py
+++ b/pyqldbsamples/scan_table.py
@@ -52,8 +52,7 @@ if __name__ == '__main__':
             # Scan all the tables and print their documents.
             tables = driver.list_tables()
             for table in tables:
-                cursor = driver.execute_lambda(
-                    lambda executor: scan_table(executor, table))
+                cursor = driver.execute_lambda(lambda executor: scan_table(executor, table))
                 logger.info('Scan successful!')
                 print_result(cursor)
     except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amazon.ion~=0.5.0
-boto3~=1.13.24
-botocore~=1.16.26
-pyqldb>=3.0.0rc1,<3.1.0
+amazon.ion~=0.7.0
+boto3~=1.16.56
+botocore~=1.19.56
+pyqldb>=3.1.0,<3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 amazon.ion~=0.7.0
 boto3~=1.16.56
 botocore~=1.19.56
-pyqldb>=3.1.0,<3.2.0
+pyqldb>=3.1.0,<4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.a-z\-]+)['"]''')
 requires = ['amazon.ion>=0.7.0,<1',
             'boto3>=1.16.56,<2',
             'botocore>=1.19.56,<2',
-            'pyqldb>=3.1.0,<3.2.0'
+            'pyqldb>=3.1.0,<4'
             ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ import setuptools
 
 ROOT = os.path.join(os.path.dirname(__file__), 'pyqldbsamples')
 VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.a-z\-]+)['"]''')
-requires = ['amazon.ion>=0.5.0,<0.6',
-            'boto3>=1.9.237,<2',
-            'botocore>=1.12.237,<2',
-            'pyqldb>=3.0.0rc1,<3.1.0'
+requires = ['amazon.ion>=0.7.0,<1',
+            'boto3>=1.16.56,<2',
+            'botocore>=1.19.56,<2',
+            'pyqldb>=3.1.0,<3.2.0'
             ]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current sample app is passing `retry_indicator` lambda to `driver.execute()` but the V3 driver `execute()` API takes in `retry_config`. 

This PR removes the `retry_indicator` lambda and will use the default `retry_config` argument.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
