### PR TITLE
Update lambda functions passed to driver.execute() to be pure

### DIFF
--- a/pyqldbsamples/create_index.py
+++ b/pyqldbsamples/create_index.py
@@ -25,12 +25,12 @@ logger = getLogger(__name__)
 basicConfig(level=INFO)
 
 
-def create_index(transaction_executor, table_name, index_attribute):
+def create_index(driver, table_name, index_attribute):
     """
     Create an index for a particular table.
 
-    :type transaction_executor: :py:class:`pyqldb.execution.executor.Executor`
-    :param transaction_executor: An Executor object allowing for execution of statements within a transaction.
+    :type driver: :py:class:`pyqldb.driver.qldb_driver.QldbDriver`
+    :param driver: An instance of the QldbDriver class.
 
     :type table_name: str
     :param table_name: Name of the table to add indexes for.
@@ -43,7 +43,7 @@ def create_index(transaction_executor, table_name, index_attribute):
     """
     logger.info("Creating index on '{}'...".format(index_attribute))
     statement = 'CREATE INDEX on {} ({})'.format(table_name, index_attribute)
-    cursor = transaction_executor.execute_statement(statement)
+    cursor = driver.execute_lambda(lambda executor: executor.execute_statement(statement))
     return len(list(cursor))
 
 
@@ -51,21 +51,15 @@ if __name__ == '__main__':
     """
     Create indexes on tables in a particular ledger.
     """
-    logger.info('Creating indexes on all tables in a single transaction...')
+    logger.info('Creating indexes on all tables...')
     try:
         with create_qldb_driver() as driver:
-            driver.execute_lambda(lambda x: create_index(x, Constants.PERSON_TABLE_NAME,
-                                                          Constants.GOV_ID_INDEX_NAME)
-                                   and create_index(x, Constants.VEHICLE_TABLE_NAME,
-                                                    Constants.VEHICLE_VIN_INDEX_NAME)
-                                   and create_index(x, Constants.VEHICLE_REGISTRATION_TABLE_NAME,
-                                                    Constants.LICENSE_PLATE_NUMBER_INDEX_NAME)
-                                   and create_index(x, Constants.VEHICLE_REGISTRATION_TABLE_NAME,
-                                                    Constants.VEHICLE_VIN_INDEX_NAME)
-                                   and create_index(x, Constants.DRIVERS_LICENSE_TABLE_NAME,
-                                                    Constants.PERSON_ID_INDEX_NAME)
-                                   and create_index(x, Constants.DRIVERS_LICENSE_TABLE_NAME,
-                                                    Constants.LICENSE_NUMBER_INDEX_NAME))
+            create_index(driver, Constants.PERSON_TABLE_NAME, Constants.GOV_ID_INDEX_NAME)
+            create_index(driver, Constants.VEHICLE_TABLE_NAME, Constants.VEHICLE_VIN_INDEX_NAME)
+            create_index(driver, Constants.VEHICLE_REGISTRATION_TABLE_NAME, Constants.LICENSE_PLATE_NUMBER_INDEX_NAME)
+            create_index(driver, Constants.VEHICLE_REGISTRATION_TABLE_NAME, Constants.VEHICLE_VIN_INDEX_NAME)
+            create_index(driver, Constants.DRIVERS_LICENSE_TABLE_NAME, Constants.PERSON_ID_INDEX_NAME)
+            create_index(driver, Constants.DRIVERS_LICENSE_TABLE_NAME, Constants.LICENSE_NUMBER_INDEX_NAME)
             logger.info('Indexes created successfully.')
     except Exception:
         logger.exception('Unable to create indexes.')

--- a/pyqldbsamples/create_table.py
+++ b/pyqldbsamples/create_table.py
@@ -25,12 +25,12 @@ logger = getLogger(__name__)
 basicConfig(level=INFO)
 
 
-def create_table(transaction_executor, table_name):
+def create_table(driver, table_name):
     """
-    Create a table with the specified name using an Executor object.
+    Create a table with the specified name.
 
-    :type transaction_executor: :py:class:`pyqldb.execution.executor.Executor`
-    :param transaction_executor: An Executor object allowing for execution of statements within a transaction.
+    :type driver: :py:class:`pyqldb.driver.qldb_driver.QldbDriver`
+    :param driver: An instance of the QldbDriver class.
 
     :type table_name: str
     :param table_name: Name of the table to create.
@@ -40,21 +40,21 @@ def create_table(transaction_executor, table_name):
     """
     logger.info("Creating the '{}' table...".format(table_name))
     statement = 'CREATE TABLE {}'.format(table_name)
-    cursor = transaction_executor.execute_statement(statement)
+    cursor = driver.execute_lambda(lambda executor: executor.execute_statement(statement))
     logger.info('{} table created successfully.'.format(table_name))
     return len(list(cursor))
 
 
 if __name__ == '__main__':
     """
-    Create registrations, vehicles, owners, and licenses tables in a single transaction.
+    Create registrations, vehicles, owners, and licenses tables.
     """
     try:
-        with create_qldb_driver() as qldb_driver:
-            qldb_driver.execute_lambda(lambda x: create_table(x, Constants.DRIVERS_LICENSE_TABLE_NAME) and
-                                   create_table(x, Constants.PERSON_TABLE_NAME) and
-                                   create_table(x, Constants.VEHICLE_TABLE_NAME) and
-                                   create_table(x, Constants.VEHICLE_REGISTRATION_TABLE_NAME))
+        with create_qldb_driver() as driver:
+            create_table(driver, Constants.DRIVERS_LICENSE_TABLE_NAME)
+            create_table(driver, Constants.PERSON_TABLE_NAME)
+            create_table(driver, Constants.VEHICLE_TABLE_NAME)
+            create_table(driver, Constants.VEHICLE_REGISTRATION_TABLE_NAME)
             logger.info('Tables created successfully.')
     except Exception:
         logger.exception('Errors creating tables.')

--- a/pyqldbsamples/deregister_drivers_license.py
+++ b/pyqldbsamples/deregister_drivers_license.py
@@ -25,12 +25,12 @@ logger = getLogger(__name__)
 basicConfig(level=INFO)
 
 
-def deregister_drivers_license(transaction_executor, license_number):
+def deregister_drivers_license(driver, license_number):
     """
     De-register a driver's license with the given license number.
 
-    :type transaction_executor: :py:class:`pyqldb.execution.executor.Executor`
-    :param transaction_executor: An Executor object allowing for execution of statements within a transaction.
+    :type driver: :py:class:`pyqldb.driver.qldb_driver.QldbDriver`
+    :param driver: An instance of the QldbDriver class.
 
     :type license_number: str
     :param license_number: The license number of the driver's license to de-register.
@@ -38,7 +38,7 @@ def deregister_drivers_license(transaction_executor, license_number):
     logger.info('De-registering license with license number: {}.'.format(license_number))
     statement = 'DELETE FROM DriversLicense AS d WHERE d.LicenseNumber = ?'
     parameter = convert_object_to_ion(license_number)
-    cursor = transaction_executor.execute_statement(statement, parameter)
+    cursor = driver.execute_lambda(lambda executor: executor.execute_statement(statement, parameter))
 
     try:
         # Check whether cursor is empty.
@@ -56,6 +56,6 @@ if __name__ == '__main__':
 
     try:
         with create_qldb_driver() as driver:
-            driver.execute_lambda(lambda executor: deregister_drivers_license(executor, license_number))
+            deregister_drivers_license(driver, license_number)
     except Exception:
         logger.exception('Error deleting driver license.')

--- a/pyqldbsamples/get_revision.py
+++ b/pyqldbsamples/get_revision.py
@@ -74,8 +74,7 @@ def lookup_registration_for_vin(driver, vin):
     """
     logger.info("Querying the 'VehicleRegistration' table for VIN: {}...".format(vin))
     query = 'SELECT * FROM _ql_committed_VehicleRegistration WHERE data.VIN = ?'
-    cursor = driver.execute_lambda(lambda txn: txn.execute_statement(query, convert_object_to_ion(vin)))
-    return cursor
+    return driver.execute_lambda(lambda txn: txn.execute_statement(query, convert_object_to_ion(vin)))
 
 
 def verify_registration(driver, ledger_name, vin):

--- a/pyqldbsamples/model/sample_data.py
+++ b/pyqldbsamples/model/sample_data.py
@@ -20,6 +20,7 @@ from logging import basicConfig, getLogger, INFO
 from amazon.ion.simple_types import IonPyBool, IonPyBytes, IonPyDecimal, IonPyDict, IonPyFloat, IonPyInt, IonPyList, \
     IonPyNull, IonPySymbol, IonPyText, IonPyTimestamp
 from amazon.ion.simpleion import dumps, loads
+from pyqldb.cursor.buffered_cursor import BufferedCursor
 
 logger = getLogger(__name__)
 basicConfig(level=INFO)
@@ -274,8 +275,7 @@ def get_document_ids(transaction_executor, table_name, field, value):
     """
     query = "SELECT id FROM {} AS t BY id WHERE t.{} = '{}'".format(table_name, field, value)
     cursor = transaction_executor.execute_statement(query)
-    list_of_ids = map(lambda table: table.get('id'), cursor)
-    return list_of_ids
+    return list(map(lambda table: table.get('id'), cursor))
 
 
 def get_document_ids_from_dml_results(result):

--- a/pyqldbsamples/model/sample_data.py
+++ b/pyqldbsamples/model/sample_data.py
@@ -281,7 +281,7 @@ def get_document_ids_from_dml_results(result):
     """
     Return a list of modified document IDs as strings from DML results.
 
-    :type result: :py:class:`pyqldb.cursor.stream_cursor.StreamCursor`
+    :type result: :py:class:`pyqldb.cursor.buffered_cursor.BufferedCursor`
     :param: result: The result set from DML operation.
 
     :rtype: list

--- a/pyqldbsamples/model/sample_data.py
+++ b/pyqldbsamples/model/sample_data.py
@@ -20,7 +20,6 @@ from logging import basicConfig, getLogger, INFO
 from amazon.ion.simple_types import IonPyBool, IonPyBytes, IonPyDecimal, IonPyDict, IonPyFloat, IonPyInt, IonPyList, \
     IonPyNull, IonPySymbol, IonPyText, IonPyTimestamp
 from amazon.ion.simpleion import dumps, loads
-from pyqldb.cursor.buffered_cursor import BufferedCursor
 
 logger = getLogger(__name__)
 basicConfig(level=INFO)

--- a/pyqldbsamples/scan_table.py
+++ b/pyqldbsamples/scan_table.py
@@ -25,22 +25,22 @@ logger = getLogger(__name__)
 basicConfig(level=INFO)
 
 
-def scan_table(transaction_executor, table_name):
+def scan_table(driver, table_name):
     """
     Scan for all the documents in a table.
 
-    :type transaction_executor: :py:class:`pyqldb.execution.executor.Executor`
-    :param transaction_executor: An Executor object allowing for execution of statements within a transaction.
+    :type driver: :py:class:`pyqldb.driver.qldb_driver.QldbDriver`
+    :param driver: An instance of the QldbDriver class.
 
     :type table_name: str
     :param table_name: The name of the table to operate on.
 
-    :rtype: :py:class:`pyqldb.cursor.stream_cursor.StreamCursor`
+    :rtype: :py:class:`pyqldb.cursor.buffered_cursor.BufferedCursor`
     :return: Cursor on the result set of a statement query.
     """
     logger.info('Scanning {}...'.format(table_name))
     query = 'SELECT * FROM {}'.format(table_name)
-    return transaction_executor.execute_statement(query)
+    return driver.execute_lambda(lambda executor: executor.execute_statement(query))
 
 
 if __name__ == '__main__':
@@ -52,7 +52,7 @@ if __name__ == '__main__':
             # Scan all the tables and print their documents.
             tables = driver.list_tables()
             for table in tables:
-                cursor = driver.execute_lambda(lambda executor: scan_table(executor, table))
+                cursor = scan_table(driver, table)
                 logger.info('Scan successful!')
                 print_result(cursor)
     except Exception:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
QLDB has a concurrency model where it has no locks and uses Optimistic Concurrency Control (OCC) which allows transactions to run concurrently but only commit serially. In the case of a conflict during commit, it will return an OCC exception and the transaction will be retried by the driver. 

Given this model, we need to update the lambda functions we pass to the driver to be pure, which hold the following conditions:

* Does not update state outside of the function
* Does not write to IO
* Does not throw exception
* Does not rely on external state


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
