### PR TITLE
Revert "Update botocore requirement from ~=1.20.105 to ~=1.20.109"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 amazon.ion~=0.7.0
 boto3~=1.17.109
-botocore~=1.20.109
+botocore~=1.20.105
 pyqldb>=3.1.0,<4


### PR DESCRIPTION
Reverts aws-samples/amazon-qldb-dmv-sample-python#50

Merging this dependabot PR caused tests on master to fail, reverting for now.