### PR TITLE
Fixing Integration Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # This value needs to match the build matrix configuration job total.
-  job-total: 9
+  job-total: 12
 
 jobs:
   generate-unique-id:
@@ -24,7 +24,7 @@ jobs:
     needs: [generate-unique-id]
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 5
+      max-parallel: 3
       matrix :
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     needs: [generate-unique-id]
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 3
+      max-parallel: 5
       matrix :
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/tests/cleanup.py
+++ b/tests/cleanup.py
@@ -103,7 +103,7 @@ def delete_resources(ledger_suffix):
     s3_bucket_name = get_s3_bucket_name(ledger_suffix)
     ledger_name = get_ledger_name(ledger_suffix)
     deletion_ledger_name = get_deletion_ledger_name(ledger_suffix)
-    tag_ledger_name = get_deletion_ledger_name(ledger_suffix)
+    tag_ledger_name = get_tag_ledger_name(ledger_suffix)
 
     force_delete_role_policies(role_name)
     force_delete_role(role_name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,7 +40,7 @@ from pyqldbsamples.tag_resource import main as tag_resource_main
 from pyqldbsamples.transfer_vehicle_ownership import main as transfer_vehicle_ownership_main
 from pyqldbsamples.validate_qldb_hash_chain import main as validate_qldb_hash_chain_main
 from tests.cleanup import get_deletion_ledger_name, get_ledger_name, get_role_name, get_role_policy_name, \
-    get_s3_bucket_name, delete_resources, poll_for_table_creation
+    get_s3_bucket_name, get_tag_ledger_name, delete_resources, poll_for_table_creation
 
 
 # The following tests only run the samples.
@@ -54,7 +54,7 @@ class TestIntegration(TestCase):
         cls.s3_bucket_name = get_s3_bucket_name(cls.ledger_suffix)
         cls.ledger_name = get_ledger_name(cls.ledger_suffix)
         cls.deletion_ledger_name = get_deletion_ledger_name(cls.ledger_suffix)
-        cls.tag_ledger_name = get_deletion_ledger_name(cls.ledger_suffix)
+        cls.tag_ledger_name = get_tag_ledger_name(cls.ledger_suffix)
 
         delete_resources(cls.ledger_suffix)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reduced number of parallel builds in github action from 5 -> 3. We were running into the ledger limit for these tests. Reducing the number of parallel builds in combination with increasing the ledger limit on our integration test account appears to have fixed the problem.

Also updated tagging integration test to -NOT- reuse the same ledger name as the deletion integration test. This caused problems if the tagging integration test started before deletion of the ledger with the same name completed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
