### PR TITLE
Update setup-python action to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
             aws-region: us-east-2
         - uses: actions/checkout@v2
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v2
           with:
             python-version: 3.8
         - name: Install dependencies


### PR DESCRIPTION
*Description of changes:*
Update setup-python action to v2 to be able to use Python3.6 on macOS. Example failed action: https://github.com/aws-samples/amazon-qldb-dmv-sample-python/runs/4216979386?check_suite_focus=true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
