### PR TITLE
Fix integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     needs: [generate-unique-id]
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix :
         os: [ubuntu-latest, windows-2019, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 5
       matrix :
         os: [ubuntu-latest, windows-2019, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix :
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, windows-2019, macos-latest]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developergui
 
 DMV Sample App v1.x requires Python 3.4 or later.
 
-DMV Sample App v2.x requires Python 3.6 or later. 
+DMV Sample App v2.x requires Python 3.7 or later.
 
 Please see the link below for more detail to install Python:
 

--- a/pyqldbsamples/journal_s3_export_reader.py
+++ b/pyqldbsamples/journal_s3_export_reader.py
@@ -177,5 +177,6 @@ def read_export(describe_journal_export_result, s3_client):
         s3_object = s3_client.get_object(Bucket=bucket_name, Key=key)['Body'].read().decode('utf-8')
         blocks = get_journal_blocks(s3_object)
         compare_key_with_content_range(key, blocks[0], blocks[len(blocks) - 1])
-        journal_blocks.append(blocks)
+        # `blocks` is also a list of journal blocks, so we need to concatenate them.
+        journal_blocks.extend(blocks)
     return journal_blocks


### PR DESCRIPTION
*Description of changes:*
- Fix windows build by using `windows-2019` instead of `windows-latest` that doesn't have VS studio set up properly
- Remove Python 3.6 from CI since it's eol and add Python 3.10
- Fix a bug that incorrectly uses List append() method to concatenate multiple list of journal blocks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
