### PR TITLE
Boto upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 amazon.ion~=0.9.3
-boto3~=1.24.93
+boto3~=1.26.14
 botocore~=1.27.92
 pyqldb>=3.1.0,<4


### PR DESCRIPTION
Changes need to go out together, dependabot PRs are failing.

Updated packages:
 * boto3 1.26.14
 * botocore 1.29.14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
