### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Generate unique id
         id: unique_id
-        run: echo "::set-output name=id::$RANDOM"
+        run: echo "id=$RANDOM" >> "$GITHUB_OUTPUT"
     outputs:
       id: ${{ steps.unique_id.outputs.id }}
 
@@ -59,7 +59,7 @@ jobs:
     - name: Test with pytest
       id: test
       run: |
-        echo "::set-output name=job-total::${{ strategy.job-total }}"
+        echo "job-total=${{ strategy.job-total }}" >> "$GITHUB_OUTPUT"
         pip install pytest
         pytest --ledger_suffix ${{ needs.generate-unique-id.outputs.id}}${{ strategy.job-index }}
     outputs:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter